### PR TITLE
Fixes avo status [source] failing when ran with a source

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1104,7 +1104,7 @@ function getSource(argv, json) {
 
 function status(source, json, argv) {
   let sources = source
-    ? _.filter(json.sources, source => matchesSource(source, source))
+    ? _.filter(json.sources, s => matchesSource(s, source))
     : json.sources;
 
   sources = sources.filter(source => source.analysis !== false);


### PR DESCRIPTION
Running `avo status some-source` would result with: `error filter.toLowerCase is not a function`
The filter variable was being shadowed with another one with a different type. This PR fixes that shadowing resulting in `avo status [source]` working as expected