### PR TITLE
Check .res as well as .re files by default when running status for a Reason source

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1156,6 +1156,9 @@ function status(source, json, argv) {
               } else if (sourcePath.ext === ".m" || sourcePath.ext === ".swift") {
                 sourcePathExts.push("m");
                 sourcePathExts.push("swift");
+              } else if (sourcePath.ext === ".re") {
+                sourcePathExts.push("re");
+                sourcePathExts.push("res");
               } else {
                 sourcePathExts.push(sourcePath.ext.substring(1));
               }


### PR DESCRIPTION
Today when `avo status` is running for a Reason source it only checks for `.re` files. This adds `.res` files as well and is in line with Reason transitioning to ReScript, hence the new file extension.