### PR TITLE
Run actions for a matrix of Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,18 @@ name: CI
 on: push
 
 jobs:
-  build:
+  build-and-check:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, latest]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Install modules
         run: yarn install --immutable


### PR DESCRIPTION
As we want the CLI to run on a variety of Node version, it should we valuable to run the CI against the most common ones. We'll have to update the required build step for merging before this one goes in.