### PR TITLE
More accurate messages on 403 server errors

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -201,8 +201,20 @@ function responseToError(response) {
   }
 
   if (!body.error) {
+    const getMessage = (statusCode) => {
+      switch (statusCode) {
+        case 401:
+          return 'Unauthorized';
+        case 403:
+          return 'Forbidden. Do you have the required permissions? Some commands editor or admin access.';
+        case 404:
+          return 'Not Found';
+        default:
+          return 'Unknown Error';
+      }
+    };
     body.error = {
-      message: response.statusCode === 404 ? 'Not Found' : 'Unknown Error',
+      message: getMessage(response.statusCode),
     };
   }
 


### PR DESCRIPTION
This is a simple one. We're working on returning 403 errors when appropriate from the `V1 pull` cloud function and here we're displaying a more actionable error message 