### PR TITLE
make postInstall compatible for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.16"
   },
   "scripts": {
-    "postinstall": "node cli.js track-install; true",
+    "postinstall": "npm run compile && node cli.js track-install",
     "prepublishOnly": "npm run compile",
     "lint": "eslint cli.ts",
     "format": "prettier --write cli.ts",


### PR DESCRIPTION
windows postinstall was failing due to the ";", once removed, it did not know of cli.js as it had never done tsc compile.