### PR TITLE
Release 3.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ yarn-error.log
 cli.js
 Avo.js
 reporter.js
+package-lock.json
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Support `interfaceFilenameHint` from backend API
 Improve CLI setup flow prompts with context-aware descriptions
-Fix consistent regeneration message for interface filename prompt
+Fix inconsistent regeneration message for interface filename prompt
 Fix helpers ordering and sourceToAdd flow in CLI setup
 Update dependencies (minimatch, flatted, semver, prettier)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## 3.5.0 (2026-03-24)
+
+Support `interfaceFilenameHint` from backend API
+Improve CLI setup flow prompts with context-aware descriptions
+Fix consistent regeneration message for interface filename prompt
+Fix helpers ordering and sourceToAdd flow in CLI setup
+Update dependencies (minimatch, flatted, semver, prettier)
+
 ## 3.4.0 (2026-02-24)
 
 Add manual login option (`avo login --force-manual` / `-m`) for environments where the local OAuth redirect doesn't work

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo",
-  "version": "3.5.0",
+  "version": "3.5.0-alpha.0",
   "type": "module",
   "description": "The command-line interface for Avo",
   "author": "Avo (https://www.avo.app)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo",
-  "version": "3.5.0-alpha.0",
+  "version": "3.5.0",
   "type": "module",
   "description": "The command-line interface for Avo",
   "author": "Avo (https://www.avo.app)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "type": "module",
   "description": "The command-line interface for Avo",
   "author": "Avo (https://www.avo.app)",


### PR DESCRIPTION
## Summary
- Bump version to 3.5.0
- Add CHANGELOG entry for 3.5.0

### What's included
- **feat:** support `interfaceFilenameHint` from backend API
- **feat:** improve CLI setup flow prompts with context-aware descriptions
- **fix:** use consistent regeneration message for interface filename prompt
- **fix:** move helpers above selectSource and fix sourceToAdd flow
- Dependency updates (minimatch, flatted, semver, prettier, @types/node)

## Test plan
- [x] `npm run build` succeeds
- [x] `avo --version` shows `3.5.0`
- [x] Publish to npm from this branch
- [x] Merge to main and tag `v3.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend support for interface filename configuration

* **Improvements**
  * Enhanced CLI setup prompts with context-aware guidance
  * Corrected CLI regeneration messaging

* **Bug Fixes**
  * Fixed CLI setup helper ordering
  * Resolved issues in the source addition process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->