### PR TITLE
fix(deps): remediate 4 high-severity Dependabot alerts (minimatch, lodash, tmp)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "resolutions": {
     "type-fest": "^3.13.1",
     "brace-expansion": "^2.0.2",
-    "tmp": "0.2.6",
+    "tmp": "0.2.7",
     "lodash": "4.18.1",
     "ignore-walk/minimatch": "5.1.8",
     "eslint/minimatch": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
   "resolutions": {
     "type-fest": "^3.13.1",
     "brace-expansion": "^2.0.2",
-    "tmp": "^0.2.4"
+    "tmp": "0.2.6",
+    "lodash": "4.18.1",
+    "ignore-walk/minimatch": "5.1.8",
+    "eslint/minimatch": "3.1.4",
+    "eslint/**/minimatch": "3.1.4",
+    "eslint-plugin-import/minimatch": "3.1.4",
+    "jest/**/minimatch": "3.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3728,10 +3728,10 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@^4.17.12, lodash@^4.17.21:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@4.18.1, lodash@^4.17.12, lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -3828,17 +3828,17 @@ mimic-response@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
   integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@3.1.4, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.4.tgz#89d910ea3970a77ac8edfd30340ccd038b758079"
+  integrity sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.2.tgz#0939d7d6f0898acbd1508abe534d1929368a8fff"
-  integrity sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==
+minimatch@5.1.8, minimatch@^5.0.1:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.8.tgz#32a16ebcccd6421c674430acb199b8806c68169b"
+  integrity sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -4885,10 +4885,10 @@ titleize@^3.0.0:
   resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
   integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
 
-tmp@^0.0.33, tmp@^0.2.4:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
-  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+tmp@0.2.6, tmp@^0.0.33:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
+  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
 
 tmpl@1.0.5:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4885,10 +4885,10 @@ titleize@^3.0.0:
   resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
   integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
 
-tmp@0.2.6, tmp@^0.0.33:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
-  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
+tmp@0.2.7, tmp@^0.0.33:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Remediates the flagged high-severity Dependabot alerts in the Avo CLI (AVO-3259) via scoped yarn `resolutions`. **No source code changes** — lockfile/resolutions only.

## Changes

| Package | From | To | Reachability | Advisory |
| -- | -- | -- | -- | -- |
| `minimatch` (3.x line) | 3.1.2 | **3.1.4** | dev toolchain (eslint, jest) | CVE-2026-27903 |
| `minimatch` (5.x line) | 5.1.2 | **5.1.8** | **production** (`ignore-walk`) | CVE-2026-26996, -27903/-27904 |
| `lodash` | 4.17.23 | **4.18.1** | **production** (via `inquirer`) | CVE-2026-4800 |
| `tmp` | 0.2.5 | **0.2.7** | via `inquirer/external-editor` | CVE-2026-44705, GHSA-7c78-jf6q-g5cm |

### ⚠️ Deviation from the plan: lodash → 4.18.1, not 4.18.0
The brief targeted `lodash@4.18.0`, but npm currently marks **4.18.0 as deprecated** — *"Bad release. Please use lodash@4.17.21 instead."* Since `4.17.21` is itself still inside the vulnerable range (≤ 4.17.23), it can't be the fix. `4.18.1` (published one day later, 2026-04-01, now `latest`, not deprecated, clean scripts/deps) is the **minimal non-deprecated patched version**, so I adopted it.

### ⚠️ tmp → 0.2.7, not 0.2.6
The initial fix pinned `tmp@0.2.6` (for CVE-2026-44705). A subsequent scan flagged **0.2.6 itself** under **GHSA-7c78-jf6q-g5cm**, so the pin was advanced to **0.2.7** (published 2026-05-27, `latest`, not deprecated, **zero dependencies**, no install scripts). This is the version the branch actually ships.

### Scoped, not bare, minimatch resolutions
The repo's direct `minimatch@^7.0.0` is already patched (resolves to 7.4.9) and is **not** flagged. To avoid clobbering it, minimatch is pinned via **scoped** resolution keys (`ignore-walk/minimatch`, `eslint/minimatch`, `eslint/**/minimatch`, `eslint-plugin-import/minimatch`, `jest/**/minimatch`) rather than a bare `minimatch` key. Verified via `yarn why`: 7.4.9 is left untouched; all 3.x → 3.1.4 and all 5.x → 5.1.8. (`tmp` and `lodash` use bare/global resolution keys, since they have no protected direct version to preserve.)

## Supply-chain protocol verification
- **7-day age rule** — all targets published well over 7 days ago (minimatch 3.1.4/5.1.8: 2026-02-25; lodash 4.18.1: 2026-04-01; tmp 0.2.7: 2026-05-27).
- **Install scripts** — none of the target versions declare `preinstall`/`install`/`postinstall`.
- **Deprecation** — all adopted versions non-deprecated (this is why 4.18.1 replaced 4.18.0).
- **Dependency-delta** — no new transitive packages introduced (minimatch keeps `brace-expansion`; tmp 0.2.7 has zero deps; lodash zero deps).
- **Lockfile-diff audit** — only these 4 packages changed; every `resolved` URL on `registry.yarnpkg.com`; all integrity hashes intact and matching the npm registry `dist.integrity`; **zero packages added**.

## Testing
- `yarn build` ✓ · `yarn lint` (0 errors) ✓ · `yarn check-format` ✓ · `yarn test` **24/24** ✓ *(build + test re-verified on current HEAD after the tmp 0.2.7 bump)*
- Smoke: `node cli.js --version` → `3.5.0` ✓ · `node cli.js status` exit 0 ✓
- `npm pack --dry-run` — published tarball file set unchanged (6 files; code artifacts byte-identical)

> Note: the org-level Dependabot alerts API isn't reachable from this session (Claude GitHub App not connected for org security endpoints), so the "re-pull live alert list" step couldn't be independently run; the fix set was cross-checked against the local dependency tree (`yarn why`) and the npm registry instead.

Resolves AVO-3259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUmYYzQBNq1ivQoXQa1UaL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency version overrides to lock to consistent, newer package versions.
  * Aligned the versions of several transitive packages to reduce the chance of install/build version conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
